### PR TITLE
Check if the getProduct() method exist instead of php_self name

### DIFF
--- a/ps_sharebuttons.php
+++ b/ps_sharebuttons.php
@@ -151,7 +151,7 @@ class Ps_Sharebuttons extends Module implements WidgetInterface
 
     public function getWidgetVariables($hookName, array $params)
     {
-        if (!isset($this->context->controller->php_self) || $this->context->controller->php_self != 'product') {
+        if (!method_exists($this->context->controller, 'getProduct')) {
             return;
         }
 


### PR DESCRIPTION
As the renderWidget is call if you need it, you have to check if the needed method exist on the current controller and not if the controller is the product one.