### PR TITLE
Remove useless smarty caching

### DIFF
--- a/ps_sharebuttons.php
+++ b/ps_sharebuttons.php
@@ -135,16 +135,9 @@ class Ps_Sharebuttons extends Module implements WidgetInterface
 
     public function renderWidget($hookName, array $params)
     {
-        $key = 'ps_sharebuttons|' . $params['product']['id_product'];
-        if (!empty($params['product']['id_product_attribute'])) {
-            $key .= '|' . $params['product']['id_product_attribute'];
-        }
+        $this->smarty->assign($this->getWidgetVariables($hookName, $params));
 
-        if (!$this->isCached($this->templateFile, $this->getCacheId($key))) {
-            $this->smarty->assign($this->getWidgetVariables($hookName, $params));
-        }
-
-        return $this->fetch($this->templateFile, $this->getCacheId($key));
+        return $this->fetch($this->templateFile);
     }
 
     public function getWidgetVariables($hookName, array $params)


### PR DESCRIPTION
There's literally nothing to cache here, redundant cache files all over the /cache folder

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | cache is useless in this module
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#19151.
| How to test?  | No behavior change. Module should work as before.
| Sponsor company  | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
