### PR TITLE
Product::getCover() is a static function

### DIFF
--- a/ps_sharebuttons.php
+++ b/ps_sharebuttons.php
@@ -156,7 +156,7 @@ class Ps_Sharebuttons extends Module implements WidgetInterface
         $sharing_url = urlencode(addcslashes($this->context->link->getProductLink($product), "'"));
         $sharing_name = urlencode(addcslashes($product->name, "'"));
 
-        $image_cover_id = $product->getCover($product->id);
+        $image_cover_id = Product::getCover($product->id);
         if (is_array($image_cover_id) && isset($image_cover_id['id_image'])) {
             $image_cover_id = (int) $image_cover_id['id_image'];
         } else {


### PR DESCRIPTION
Product::getCover() is a static function

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
