### PR TITLE
change the link to share a product and the name of Twitter by X

### DIFF
--- a/ps_sharebuttons.php
+++ b/ps_sharebuttons.php
@@ -63,7 +63,7 @@ class Ps_Sharebuttons extends Module implements WidgetInterface
     public function install()
     {
         if (!$this->uninstallPrestaShop16Module()) {
-            Configuration::updateValue('PS_SC_TWITTER', 1);
+            Configuration::updateValue('PS_SC_X', 1);
             Configuration::updateValue('PS_SC_FACEBOOK', 1);
             Configuration::updateValue('PS_SC_PINTEREST', 1);
         }
@@ -204,8 +204,8 @@ class Ps_Sharebuttons extends Module implements WidgetInterface
             ];
         }
 
-        if (Configuration::get('PS_SC_TWITTER')) {
-            $social_share_links['twitter'] = [
+        if (Configuration::get('PS_SC_X')) {
+            $social_share_links['X'] = [
                 'label' => $this->trans('Tweet', [], 'Modules.Sharebuttons.Shop'),
                 'class' => 'twitter',
                 'url' => 'https://x.com/intent/post?text=' . $sharing_name . ' ' . $sharing_url,

--- a/ps_sharebuttons.php
+++ b/ps_sharebuttons.php
@@ -37,7 +37,7 @@ class Ps_Sharebuttons extends Module implements WidgetInterface
      */
     const PS_16_EQUIVALENT_MODULE = 'socialsharing';
 
-    protected static $networks = ['Facebook', 'Twitter', 'Pinterest'];
+    protected static $networks = ['Facebook', 'X', 'Pinterest'];
 
     private $templateFile;
 
@@ -208,7 +208,7 @@ class Ps_Sharebuttons extends Module implements WidgetInterface
             $social_share_links['twitter'] = [
                 'label' => $this->trans('Tweet', [], 'Modules.Sharebuttons.Shop'),
                 'class' => 'twitter',
-                'url' => 'https://twitter.com/intent/tweet?text=' . $sharing_name . ' ' . $sharing_url,
+                'url' => 'https://x.com/intent/post?text=' . $sharing_name . ' ' . $sharing_url,
             ];
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | I change the name of Twitter to be X and I also change the link of the share button 
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/ps_sharebuttons/issues/71 
| How to test?  | Go to Module manager, search for "social", clic on "Social media share buttons", you should have X now / Go to FO, clic on X, now you're redirected to X with the correct link.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
